### PR TITLE
Remove babelify from runtime bundling config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,17 +35,5 @@
 		"documentation": "^5.3.3",
 		"replace-between": "0.0.8",
 		"uglify-js": "^3.3.3"
-	},
-	"browserify": {
-		"transform": [
-			[
-				"babelify",
-				{
-					"presets": [
-						"env"
-					]
-				}
-			]
-		]
 	}
 }


### PR DESCRIPTION
Attempting to include aframe-extras in a bundle via browserify's `require` statement generates the following error:

```
Error: Cannot find module 'babelify' from [three-pathfinding folder in node_modules]
```

The `browserify.transform` field is invoked even when the package is bundled as a dependency ([browserify handbook](https://github.com/browserify/browserify-handbook#browserifytransform-field)), but `babelify` is not specified in the runtime dependencies.

I don't see the transform specified in the dist script, so it may need editing if a babelified distribution file is desired. 