### PR TITLE
Fix bug with overlapping groups

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -116,7 +116,7 @@
 
 			let camera, scene, renderer, controls, raycaster;
 
-			let player, target, level;
+			let player, target, level, levelNav;
 
 			let playerNavMeshGroup, pathLines, calculatedPath;
 
@@ -168,13 +168,13 @@
 					navWireframe.position.y = OFFSET / 2;
 					scene.add(navWireframe);
 
-					var mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({
+					levelNav = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({
 						color: Color.NAVMESH,
 						opacity: 0.75,
 						transparent: true
 					}));
 
-					scene.add(mesh);
+					scene.add(levelNav);
 
 					// Set the player's navigation mesh group
 					playerNavMeshGroup = pathfinder.getGroup('level', player.position);
@@ -224,7 +224,7 @@
 
 				raycaster.setFromCamera( mouse, camera );
 
-				var intersects = raycaster.intersectObject( level );
+				var intersects = raycaster.intersectObject( levelNav );
 
 				if ( intersects.length > 0 ) {
 					var vec = intersects[0].point;
@@ -233,19 +233,29 @@
 					// Teleport on ctrl/cmd click or RMB.
 					if (event.metaKey || event.ctrlKey || event.button === 2) {
 						player.position.copy(target.position);
-						playerNavMeshGroup = pathfinder.getGroup('level', player.position);
-						const closestNode = pathfinder.getClosestNode(player.position, 'level', playerNavMeshGroup);
-						closestNodeMarker.position.copy(closestNode.centroid);
+						playerNavMeshGroup = pathfinder.getGroup('level', player.position, true);
 						clampedStepMarker.visible = false;
 						if (pathLines) scene.remove(pathLines);
 						if (calculatedPath) calculatedPath.length = 0;
+						const closestNode = pathfinder.getClosestNode(player.position, 'level', playerNavMeshGroup, true);
+						if (closestNode) {
+							closestNodeMarker.visible = true;
+							closestNodeMarker.position.copy(closestNode.centroid);
+						} else {
+							closestNodeMarker.visible = false;
+						}
 						return;
 					}
 
 
-					const targetGroup = pathfinder.getGroup('level', target.position);
-					const closestTargetNode = pathfinder.getClosestNode(target.position, 'level', targetGroup);
-					closestNodeMarker.position.copy(closestTargetNode.centroid);
+					const targetGroup = pathfinder.getGroup('level', target.position, true);
+					const closestTargetNode = pathfinder.getClosestNode(target.position, 'level', targetGroup, true);
+					if (closestTargetNode) {
+						closestNodeMarker.visible = true;
+						closestNodeMarker.position.copy(closestTargetNode.centroid);
+					} else {
+						closestNodeMarker.visible = false;
+					}
 
 					// Calculate a path to the target and store it
 					calculatedPath = pathfinder.findPath(player.position, target.position, 'level', playerNavMeshGroup);

--- a/demo/index.html
+++ b/demo/index.html
@@ -116,7 +116,7 @@
 
 			let camera, scene, renderer, controls, raycaster;
 
-			let player, target, level, levelNav;
+			let player, target, level, navMesh;
 
 			let playerNavMeshGroup, pathLines, calculatedPath;
 
@@ -168,13 +168,13 @@
 					navWireframe.position.y = OFFSET / 2;
 					scene.add(navWireframe);
 
-					levelNav = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({
+					navMesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({
 						color: Color.NAVMESH,
 						opacity: 0.75,
 						transparent: true
 					}));
 
-					scene.add(levelNav);
+					scene.add(navMesh);
 
 					// Set the player's navigation mesh group
 					playerNavMeshGroup = pathfinder.getGroup('level', player.position);
@@ -224,7 +224,7 @@
 
 				raycaster.setFromCamera( mouse, camera );
 
-				var intersects = raycaster.intersectObject( levelNav );
+				var intersects = raycaster.intersectObject( navMesh );
 
 				if ( intersects.length > 0 ) {
 					var vec = intersects[0].point;

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ Pathfinding.prototype.getGroup = (function() {
 						zone.vertices[node.vertexIds[1]],
 						zone.vertices[node.vertexIds[2]]
 					);
-					if (Math.abs(plane.distanceToPoint(position)) < 0.0001) {
+					if (Math.abs(plane.distanceToPoint(position)) < 0.01) {
 						const poly = [
 							zone.vertices[node.vertexIds[0]],
 							zone.vertices[node.vertexIds[1]],

--- a/src/index.js
+++ b/src/index.js
@@ -40,43 +40,6 @@ class Pathfinding {
 	}
 
 	/**
-	 * Returns closest node group ID for given position.
-	 * @param  {string} zoneID
-	 * @param  {THREE.Vector3} position
-	 * @return {number}
-	 */
-	getGroup (zoneID, position, checkPolygon = false) {
-		if (!this.zones[zoneID]) return null;
-
-		let closestNodeGroup = null;
-		let distance = Math.pow(50, 2);
-		const zone = this.zones[zoneID];
-
-		for (let i = 0; i < zone.groups.length; i++) {
-			const group = zone.groups[i];
-			for (const node of group) {
-				if (checkPolygon) {
-					const poly = [
-						zone.vertices[node.vertexIds[0]],
-						zone.vertices[node.vertexIds[1]],
-						zone.vertices[node.vertexIds[2]]
-					];
-					if(Utils.isPointInPoly(poly, position)) {
-						return i;
-					}
-				}
-				const measuredDistance = Utils.distanceToSquared(node.centroid, position);
-				if (measuredDistance < distance) {
-					closestNodeGroup = i;
-					distance = measuredDistance;
-				}
-			}
-		}
-
-		return closestNodeGroup;
-	}
-
-	/**
 	 * Returns a random node within a given range of a given position.
 	 * @param  {string} zoneID
 	 * @param  {number} groupID
@@ -189,6 +152,43 @@ class Pathfinding {
 		return path;
 	}
 }
+
+/**
+ * Returns closest node group ID for given position.
+ * @param  {string} zoneID
+ * @param  {THREE.Vector3} position
+ * @return {number}
+ */
+Pathfinding.prototype.getGroup = function (zoneID, position, checkPolygon = false) {
+	if (!this.zones[zoneID]) return null;
+
+	let closestNodeGroup = null;
+	let distance = Math.pow(50, 2);
+	const zone = this.zones[zoneID];
+
+	for (let i = 0; i < zone.groups.length; i++) {
+		const group = zone.groups[i];
+		for (const node of group) {
+			if (checkPolygon) {
+				const poly = [
+					zone.vertices[node.vertexIds[0]],
+					zone.vertices[node.vertexIds[1]],
+					zone.vertices[node.vertexIds[2]]
+				];
+				if(Utils.isPointInPoly(poly, position)) {
+					return i;
+				}
+			}
+			const measuredDistance = Utils.distanceToSquared(node.centroid, position);
+			if (measuredDistance < distance) {
+				closestNodeGroup = i;
+				distance = measuredDistance;
+			}
+		}
+	}
+
+	return closestNodeGroup;
+};
 
 /**
  * Clamps a step along the navmesh, given start and desired endpoint. May be

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -93,7 +93,7 @@ test('pathing near close nodes in a different group', (t) => {
   t.end();
 });
 
-test('overlapping groups', (t) => {
+test('vertically stacked groups', (t) => {
   const pathfinding = new Pathfinding();
 
   const geometry = new THREE.Geometry();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -92,3 +92,29 @@ test('pathing near close nodes in a different group', (t) => {
 
   t.end();
 });
+
+test('overlapping groups', (t) => {
+  const pathfinding = new Pathfinding();
+
+  const geometry = new THREE.Geometry();
+  geometry.vertices.push(
+    new THREE.Vector3(  0,  0,  0  ),
+    new THREE.Vector3(  0,  0,  1  ),
+    new THREE.Vector3(  1,  0,  0  ),
+    new THREE.Vector3(  0,  1,  0  ),
+    new THREE.Vector3(  0,  1,  1  ),
+    new THREE.Vector3(  1,  1,  0  ),
+  );
+  geometry.faces.push( new THREE.Face3( 0, 1, 2 ) );
+  geometry.faces.push( new THREE.Face3( 3, 4, 5 ) );
+
+  const zone = Pathfinding.createZone(geometry);
+  pathfinding.setZoneData(ZONE, zone);
+  t.equal(zone.groups[1][0].centroid.y, 1, 'centroid of node in group 1 should be at y=1');
+
+  const a = new THREE.Vector3(0.2, 1, 0.2);
+  const groupID = pathfinding.getGroup(ZONE, a, true);
+  t.equal(groupID, 1, 'point on node at y=1 should be in group 1');
+
+  t.end();
+});


### PR DESCRIPTION
Fixes a bug in #23. I didn't realize that `isPointInPoly` effectively projects the point onto the poly first.

Also changed the demo to raycast against the nav mesh and use the `checkPolygon` flag so that code is actually exercised. This also fixes the scenario I demonstrated in #23, but it means that you can't teleport to non-navmeshed areas of the level. Not sure if that was important to you.