### PR TITLE
Fix bug in demo teleport

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -152,10 +152,10 @@
 			// Teleport on ctrl/cmd click or RMB.
 			if (event.metaKey || event.ctrlKey || event.button === 2) {
 
-				path.length = 0;
+				path = null;
 				groupID = pathfinder.getGroup(ZONE, targetPosition, true);
 				const closestNode = pathfinder.getClosestNode( playerPosition, ZONE, groupID, true );
-				
+
 				helper.setPlayerPosition( playerPosition.copy( targetPosition ) )
 				if ( closestNode ) helper.setNodePosition( closestNode.centroid );
 


### PR DESCRIPTION
This was broken if the previous action was to attempt to path to an unpathable location, causing `path` to already be `null`. (That is, to reproduce the bug, first left-click to somewhere unpathable, and then try right-clicking to teleport.)