### PR TITLE
Faster building

### DIFF
--- a/benchmark/index.benchmark.js
+++ b/benchmark/index.benchmark.js
@@ -1,0 +1,31 @@
+const THREE = global.THREE = require('three');
+const { Pathfinding } = require('../');
+const process = require('process');
+
+const NS_PER_SEC = 1e9;
+const NS_PER_MS = 1e6;
+
+function formatElapsed(ns) {
+  return `${(ns / NS_PER_MS).toFixed(2)}ms`;
+}
+
+function run(name, func, iterations) {
+  const times = [];
+  for (let i = 0; i < iterations; i++) {
+    let start = process.hrtime();
+	func();
+    let elapsed = process.hrtime(start);
+    times.push(elapsed[0] * NS_PER_SEC + elapsed[1]);
+  }
+
+  const min = Math.min.apply(null, times);
+  const max = Math.max.apply(null, times);
+  const avg = times.reduce(((t, acc) => t + acc), 0) / iterations;
+  console.log(`${name}: min=${formatElapsed(min)} max=${formatElapsed(max)} avg=${formatElapsed(avg)}`);
+}
+
+const geometry = new THREE.RingBufferGeometry(5, 20, 50, 20);
+
+run('Build navmesh', () => {
+  const zone = Pathfinding.createZone(geometry);
+}, 100);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"version": "npm run dist && npm test && git add -A dist",
 		"postversion": "git push && git push --tags && npm publish",
 		"test": "node tests/index.test.js",
+		"benchmark": "node benchmark/index.benchmark.js",
 		"deploy": "npm run dist && npm test && now --static && now alias"
 	},
 	"now": {

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -24,7 +24,7 @@ class Builder {
 
     const groups = this._buildPolygonGroups(navMesh);
 
-    // TODO: This block represents 50-60% of navigation mesh construction time,
+    // TODO: This block represents a large portion of navigation mesh construction time
     // and could probably be optimized. For example, construct portals while
     // determining the neighbor graph.
     zone.groups = new Array(groups.length);
@@ -36,10 +36,12 @@ class Builder {
       const newGroup = new Array(group.length);
       group.forEach((p, j) => {
 
-        const neighbourIndices = p.neighbours.map((n) => indexByPolygonId[n.id]);
+        const neighbourIndices = [];
+        p.neighbours.forEach((n) => neighbourIndices.push(indexByPolygonId[n.id]));
 
         // Build a portal list to each neighbour
-        const portals = p.neighbours.map((n) => this._getSharedVerticesInOrder(p, n));
+        const portals = [];
+        p.neighbours.forEach((n) => portals.push(this._getSharedVerticesInOrder(p, n)));
 
         p.centroid.x = Utils.roundNumber(p.centroid.x, 2);
         p.centroid.y = Utils.roundNumber(p.centroid.y, 2);
@@ -126,7 +128,7 @@ class Builder {
       }
     });
 
-    return Array.from(neighbours);
+    return neighbours;
   }
 
   static _buildPolygonsFromGeometry (geometry) {

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -113,22 +113,22 @@ class Builder {
   static _buildPolygonNeighbours (polygon, navigationMesh, vertexPolygonMap) {
     const neighbors = new Set();
 
-    const groupA = vertexPolygonMap.get(polygon.vertexIds[0]);
-    const groupB = vertexPolygonMap.get(polygon.vertexIds[1]);
-    const groupC = vertexPolygonMap.get(polygon.vertexIds[2]);
+    const groupA = vertexPolygonMap[polygon.vertexIds[0]];
+    const groupB = vertexPolygonMap[polygon.vertexIds[1]];
+    const groupC = vertexPolygonMap[polygon.vertexIds[2]];
 
     // It's only necessary to iterate groups A and B. Polygons contained only
     // in group C cannot share a >1 vertex with this polygon.
     // IMPORTANT: Bublé cannot compile for-of loops.
     groupA.forEach((candidate) => {
       if (navigationMesh.polygons[candidate] === polygon) return;
-      if (groupB.has(candidate) || groupC.has(candidate)) {
+      if (groupB.includes(candidate) || groupC.includes(candidate)) {
         neighbors.add(navigationMesh.polygons[candidate]);
       }
     });
     groupB.forEach((candidate) => {
       if (navigationMesh.polygons[candidate] === polygon) return;
-      if (groupC.has(candidate)) {
+      if (groupC.includes(candidate)) {
         neighbors.add(navigationMesh.polygons[candidate]);
       }
     });
@@ -146,9 +146,9 @@ class Builder {
     // create a map from vertices to the polygons that contain them, and use it
     // while connecting polygons. This reduces complexity to O(n*m), where 'm'
     // is related to connectivity of the mesh.
-    const vertexPolygonMap = new Map(); // Map<vertexID, Set<polygonIndex>>
+    const vertexPolygonMap = new Array(vertices.length); // array of polygon indices by vertex index
     for (let i = 0; i < vertices.length; i++) {
-      vertexPolygonMap.set(i, new Set());
+      vertexPolygonMap[i] = [];
     }
 
     // Convert the faces into a custom format that supports more than 3 vertices
@@ -160,9 +160,10 @@ class Builder {
         normal: face.normal,
         neighbours: []
       });
-      vertexPolygonMap.get(face.a).add(polygons.length - 1);
-      vertexPolygonMap.get(face.b).add(polygons.length - 1);
-      vertexPolygonMap.get(face.c).add(polygons.length - 1);
+
+      vertexPolygonMap[face.a].push(polygons.length - 1);
+      vertexPolygonMap[face.b].push(polygons.length - 1);
+      vertexPolygonMap[face.c].push(polygons.length - 1);
     });
 
     const navigationMesh = {

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -28,35 +28,35 @@ class Builder {
     // and could probably be optimized. For example, construct portals while
     // determining the neighbor graph.
     zone.groups = new Array(groups.length);
-    groups.forEach((group, i) => {
+    groups.forEach((group, groupIndex) => {
 
       const indexByPolygonId = {};
-      group.forEach((p, j) => { indexByPolygonId[p.id] = j; });
+      group.forEach((poly, polyIndex) => { indexByPolygonId[poly.id] = polyIndex; });
 
       const newGroup = new Array(group.length);
-      group.forEach((p, j) => {
+      group.forEach((poly, polyIndex) => {
 
         const neighbourIndices = [];
-        p.neighbours.forEach((n) => neighbourIndices.push(indexByPolygonId[n.id]));
+        poly.neighbours.forEach((n) => neighbourIndices.push(indexByPolygonId[n.id]));
 
         // Build a portal list to each neighbour
         const portals = [];
-        p.neighbours.forEach((n) => portals.push(this._getSharedVerticesInOrder(p, n)));
+        poly.neighbours.forEach((n) => portals.push(this._getSharedVerticesInOrder(poly, n)));
 
-        p.centroid.x = Utils.roundNumber(p.centroid.x, 2);
-        p.centroid.y = Utils.roundNumber(p.centroid.y, 2);
-        p.centroid.z = Utils.roundNumber(p.centroid.z, 2);
+        poly.centroid.x = Utils.roundNumber(poly.centroid.x, 2);
+        poly.centroid.y = Utils.roundNumber(poly.centroid.y, 2);
+        poly.centroid.z = Utils.roundNumber(poly.centroid.z, 2);
 
-        newGroup[j] = {
-          id: j,
+        newGroup[polyIndex] = {
+          id: polyIndex,
           neighbours: neighbourIndices,
-          vertexIds: p.vertexIds,
-          centroid: p.centroid,
+          vertexIds: poly.vertexIds,
+          centroid: poly.centroid,
           portals: portals
         };
       });
 
-      zone.groups[i] = newGroup;
+      zone.groups[groupIndex] = newGroup;
     });
 
     return zone;

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -153,7 +153,7 @@ class Builder {
         vertexIds: [face.a, face.b, face.c],
         centroid: face.centroid,
         normal: face.normal,
-        neighbours: []
+        neighbours: null
       };
       polygons.push(poly);
       vertexPolygonMap[face.a].push(poly);

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -78,7 +78,6 @@ class Builder {
     const polygons = navigationMesh.polygons;
 
     const polygonGroups = [];
-    let groupCount = 0;
 
     const spreadGroupId = function (polygon) {
       polygon.neighbours.forEach((neighbour) => {
@@ -90,16 +89,15 @@ class Builder {
     };
 
     polygons.forEach((polygon) => {
-
-      if (polygon.group === undefined) {
-        polygon.group = groupCount++;
-        // Spread it
+      if (polygon.group !== undefined) {
+        // this polygon is already part of a group
+        polygonGroups[polygon.group].push(polygon);
+      } else {
+        // we need to make a new group and spread its ID to neighbors
+        polygon.group = polygonGroups.length;
         spreadGroupId(polygon);
+        polygonGroups.push([polygon]);
       }
-
-      if (!polygonGroups[polygon.group]) polygonGroups[polygon.group] = [];
-
-      polygonGroups[polygon.group].push(polygon);
     });
 
     return polygonGroups;


### PR DESCRIPTION
According to the benchmark script I made, this makes building roughly twice as fast for me on the benchmark geometry. Functionality should be identical unless I made a mistake. Some thoughts:

- Arrays in the `vertexPolygonMap` seem faster than sets, since in the vast majority of cases any vertex will belong to only a very small handful of triangles.
- We could have a more-efficient-to-build public API for the zone by reproducing the `polygons` array and having group entries be pointers into it (and group entry neighbours be pointers into it) instead of expending extra effort to rewrite those into indices into the group.
- I'm slightly concerned about the recursive implementation of `buildPolygonGroups`, because it seems to me that many realistic meshes might have a long strip of N adjacent polygons, causing N stack frames and a plausible risk of overflow. I might suggest reimplementing this with an explicit stack. (Or doing the group assignment in the same code where we compute the neighbors graph.)