### PR TITLE
Make rounding not create garbage strings

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,7 +1,8 @@
 class Utils {
 
   static roundNumber (value, decimals) {
-    return Number(value.toFixed(decimals));
+    const factor = Math.pow(10, decimals);
+    return Math.round(value * factor) / factor;
   }
 
   static sample (list) {


### PR DESCRIPTION
This makes the navigation mesh creation benchmark about 25% faster on my box. I buy it, too, because we are doing multiple rounding operations per vertex in the input geometry, so it was pretty bad to do it the old way.

This version might have different results around 0.5 and it might have some floating-point precision issues with e.g. large input values, but it seems like we don't care about the details for our purposes.