### PR TITLE
Update browserslist to ensure ES6 Classes are kept.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,9 +3,9 @@
 <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 <title>three-pathfinding demo</title>
 <link href="style.css" rel="stylesheet">
-<script src="https://unpkg.com/three@0.124.0/build/three.min.js"></script>
-<script src="https://unpkg.com/three@0.124.0/examples/js/controls/OrbitControls.js"></script>
-<script src="https://unpkg.com/three@0.124.0/examples/js/loaders/GLTFLoader.js"></script>
+<script src="https://unpkg.com/three@0.135.0/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.135.0/examples/js/controls/OrbitControls.js"></script>
+<script src="https://unpkg.com/three@0.135.0/examples/js/loaders/GLTFLoader.js"></script>
 <script src="../dist/three-pathfinding.umd.js"></script>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
 	"main": "dist/three-pathfinding.js",
 	"module": "dist/three-pathfinding.module.js",
 	"source": "src/index.js",
+	"browserslist": [
+		"last 2 versions and > 1%",
+		"maintained node versions"
+	],
 	"scripts": {
 		"dev": "concurrently \"microbundle watch --target web --globals three=THREE --external three\" \"serve --listen 5000\"",
 		"docs": "documentation build src/Pathfinding.js src/PathfindingHelper.js --shallow -f md | replace-between --target README.md --token API",


### PR DESCRIPTION
Fixes #118.

Recent versions of three.js are based on ES6 Classes, which means that objects extending base three.js classes like Object3D must also use ES6 Classes. The default compile settings were targeting much older browsers, and transpiled classes out. This update to the browserslist settings fixes that and retains more modern JS features.