### PR TITLE
Renamed *BufferGeometry to *Geometry, updated demo.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,10 +3,16 @@
 <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 <title>three-pathfinding demo</title>
 <link href="style.css" rel="stylesheet">
-<script src="https://unpkg.com/three@0.135.0/build/three.min.js"></script>
-<script src="https://unpkg.com/three@0.135.0/examples/js/controls/OrbitControls.js"></script>
-<script src="https://unpkg.com/three@0.135.0/examples/js/loaders/GLTFLoader.js"></script>
-<script src="../dist/three-pathfinding.umd.js"></script>
+ <script type="importmap">
+	{
+		"imports": {
+			"three": "https://unpkg.com/three@0.149.0/build/three.module.js",
+			"orbitcontrols": "https://unpkg.com/three@0.149.0/examples/jsm/controls/OrbitControls.js",
+			"gltf-loader": "https://unpkg.com/three@0.149.0/examples/jsm/loaders/GLTFLoader.js",
+			"three-pathfinding": "../dist/three-pathfinding.module.js"
+		}
+	}
+</script>
 
 <body>
 
@@ -27,8 +33,11 @@
 		</div>
 	</header>
 
-	<script>
-		/* global threePathfinding */
+	<script type="module">
+		import * as THREE from 'three';
+		import { OrbitControls } from 'orbitcontrols';
+		import { Pathfinding, PathfindingHelper, } from 'three-pathfinding';
+		import { GLTFLoader } from 'gltf-loader';
 
 		const Color = {
 			GROUND: new THREE.Color( 0x606060 ).convertSRGBToLinear().getHex(),
@@ -39,9 +48,6 @@
 		const SPEED = 5;
 		const OFFSET = 0.2;
 
-		THREE.Pathfinding = threePathfinding.Pathfinding;
-		THREE.PathfindingHelper = threePathfinding.PathfindingHelper;
-
 		let level, navmesh;
 
 		let groupID, path;
@@ -49,8 +55,8 @@
 		const playerPosition = new THREE.Vector3( -3.5, 0.5, 5.5 );
 		const targetPosition = new THREE.Vector3();
 
-		const pathfinder = new THREE.Pathfinding();
-		const helper = new THREE.PathfindingHelper();
+		const pathfinder = new Pathfinding();
+		const helper = new PathfindingHelper();
 		const clock = new THREE.Clock();
 		const mouse = new THREE.Vector2();
 		const mouseDown = new THREE.Vector2();
@@ -71,7 +77,7 @@
 		renderer.outputEncoding = THREE.sRGBEncoding;
 		document.body.appendChild( renderer.domElement );
 
-		const controls = new THREE.OrbitControls( camera, renderer.domElement );
+		const controls = new OrbitControls( camera, renderer.domElement );
 		controls.damping = 0.2;
 
 		const ambient = new THREE.AmbientLight( 0x101030 );
@@ -86,7 +92,7 @@
 
 		function init() {
 
-			const gltfLoader = new THREE.GLTFLoader();
+			const gltfLoader = new GLTFLoader();
 
 			gltfLoader.load( 'meshes/level.glb', function( gltf ) {
 
@@ -107,7 +113,7 @@
 				const _navmesh = gltf.scene.getObjectByName('Navmesh_Mesh');
 
 				console.time('createZone()');
-				const zone = THREE.Pathfinding.createZone(_navmesh.geometry);
+				const zone = Pathfinding.createZone(_navmesh.geometry);
 				console.timeEnd('createZone()');
 
 				pathfinder.setZoneData( ZONE, zone );

--- a/src/PathfindingHelper.js
+++ b/src/PathfindingHelper.js
@@ -1,5 +1,6 @@
 import {
-  BoxBufferGeometry,
+  BoxGeometry,
+  SphereGeometry,
   BufferAttribute,
   BufferGeometry,
   Color,
@@ -8,7 +9,6 @@ import {
   Mesh,
   MeshBasicMaterial,
   Object3D,
-  SphereBufferGeometry,
   Vector3,
 } from 'three';
 
@@ -31,24 +31,24 @@ class PathfindingHelper extends Object3D {
     super();
 
     this._playerMarker = new Mesh(
-      new SphereBufferGeometry( 0.25, 32, 32 ),
+      new SphereGeometry( 0.25, 32, 32 ),
       new MeshBasicMaterial( { color: colors.PLAYER } )
     );
 
     this._targetMarker = new Mesh(
-      new BoxBufferGeometry( 0.3, 0.3, 0.3 ),
+      new BoxGeometry( 0.3, 0.3, 0.3 ),
       new MeshBasicMaterial( { color: colors.TARGET } )
     );
 
 
     this._nodeMarker = new Mesh(
-      new BoxBufferGeometry( 0.1, 0.8, 0.1 ),
+      new BoxGeometry( 0.1, 0.8, 0.1 ),
       new MeshBasicMaterial( { color: colors.CLOSEST_NODE } )
     );
 
 
     this._stepMarker = new Mesh(
-      new BoxBufferGeometry( 0.1, 1, 0.1 ),
+      new BoxGeometry( 0.1, 1, 0.1 ),
       new MeshBasicMaterial( { color: colors.CLAMPED_STEP } )
     );
 
@@ -56,7 +56,7 @@ class PathfindingHelper extends Object3D {
 
     this._pathLineMaterial = new LineBasicMaterial( { color: colors.PATH, linewidth: 2 } ) ;
     this._pathPointMaterial = new MeshBasicMaterial( { color: colors.WAYPOINT } );
-    this._pathPointGeometry = new SphereBufferGeometry( 0.08 );
+    this._pathPointGeometry = new SphereGeometry( 0.08 );
 
     this._markers = [
       this._playerMarker,


### PR DESCRIPTION
- Renamed SphereBufferGeometry to SphereGeometry
- Renamed BoxBufferGeoemtry to BoxGeometry
- Updated demo

Why `importmap`? Because the newer versions of threejs don't roll out non module examples anymore. Here is a comparison:

https://unpkg.com/browse/three@0.135.0/examples/
https://unpkg.com/browse/three@0.149.0/examples/

Please let me know if something else needs to be updated.